### PR TITLE
Fix WPCS issues

### DIFF
--- a/azrcrv-redirect.php
+++ b/azrcrv-redirect.php
@@ -118,6 +118,7 @@ function register_admin_styles() {
  * @since 1.0.0
  */
 function enqueue_admin_styles() {
+	// phpcs:ignore WordPress.Security.NonceVerification.Recommended
 	if ( isset( $_GET['page'] ) && ( $_GET['page'] == 'azrcrv-r' || $_GET['page'] == 'azrcrv-r-mr' ) ) {
 		wp_enqueue_style( 'azrcrv-r-admin-styles' );
 	}
@@ -299,6 +300,7 @@ function display_options() {
 		</h1>
 		<?php
 
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		if ( isset( $_GET['settings-updated'] ) ) {
 			echo '<div class="notice notice-success is-dismissible">
 					<p><strong>' . esc_html__( 'Settings have been saved.', 'azrcrv-r' ) . '</strong></p>
@@ -385,7 +387,10 @@ function display_options() {
 
 				<div id="tabs">
 					<div id="tab-panel-1" >
-						<?php echo $tab_1; ?>
+						<?php
+						// String prepared above is safe.
+						// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+						echo $tab_1; ?>
 					</div>
 				</div>
 			</fieldset>
@@ -541,10 +546,13 @@ function display_manage_redirects() {
 
 				$id = (int) $_POST['id'];
 
-				// "complex" placeholder used as string cannot be wrapped in single quotes.
+				// "complex" placeholder used intentionally so that table name
+				// is not wrapped in single quotes.
+				// phpcs:ignore WordPress.DB.PreparedSQLPlaceholders.UnquotedComplexPlaceholder
 				$sql = $wpdb->prepare( 'SELECT source_url,redirect_type,destination_url FROM %1s WHERE id = %d LIMIT 0,1', $tablename, $id );
 
-				// wpdb->prepare used above.
+				// $wpdb->prepare used above.
+				// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
 				$row = $wpdb->get_row( $sql );
 
 				if ( $row ) {
@@ -633,11 +641,14 @@ function display_manage_redirects() {
 		$page_end = $redirect_rows;
 		$limit    = $page_start . ', ' . $page_end;
 
-		// "complex" placeholder used as string cannot be wrapped in single quotes.
 		$date_format = '%Y-%m-%d';
+		// "complex" placeholders used intentionally so that date format and
+		// table name are not wrapped in single quotes.
+		// phpcs:ignore WordPress.DB.PreparedSQLPlaceholders.UnquotedComplexPlaceholder
 		$sql         = $wpdb->prepare( "SELECT id,source_url,redirect_count,DATE_FORMAT(last_redirect, '%1s') AS last_redirect,status,redirect_type,destination_url FROM %2s ORDER BY source_url LIMIT %3s", $date_format, $tablename, $limit );
 
 		// wpdb->prepare used above.
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
 		$resultset = $wpdb->get_results( $sql );
 
 		$tab_2 = '<h2>' . esc_html__( 'Current Redirects', 'azrcrv-r' ) . '</h2>
@@ -796,7 +807,10 @@ function display_manage_redirects() {
 
 						<div id="tabs">
 							<div id="tab-panel-1" >
-								<?php echo $tab_1; ?>
+								<?php
+								// String prepared above is safe.
+								// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+								echo $tab_1; ?>
 							</div>
 						</div>
 					</fieldset>
@@ -807,14 +821,19 @@ function display_manage_redirects() {
 					} else {
 						$button_text = esc_html__( 'Edit redirect', 'azrcrv-r' );
 					}
-					?>
+					// String prepared above is safe.
+					// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 					<input type="submit" name="btn_add" value="<?php echo $button_text; ?>" class="button-primary"/>
 				</form>
 
 			</div>
 			<div id="tab-panel-2" >
 				<?php
+					// String prepared above is safe.
+					// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 					echo $tab_2;
+					// get_pagination() is safe.
+					// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 					echo '<div class=azrcrv-r-pagination>' . get_pagination( $redirect_rows ) . '</div>';
 				?>
 			</div>
@@ -868,10 +887,12 @@ function manage_redirects() {
 
 				} else {
 
-					// "complex" placeholder used as string cannot be wrapped in single quotes.
 					$sql = "UPDATE %1s SET status = CASE WHEN status = 'enabled' THEN 'disabled' ELSE 'enabled' END WHERE id = %d";
 
-					// string with palceholders created above.
+					// String with palceholders created above. Note, "complex"
+					// placeholder used intentionally so that table name is not
+					// wrapped in single quotes.
+					// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
 					$wpdb->query( $wpdb->prepare( $sql, $tablename, esc_attr( $id ) ) );
 
 					wp_safe_redirect( add_query_arg( 'page', 'azrcrv-r-mr&refresh' . esc_html( $page ), admin_url( 'admin.php' ) ) );
@@ -898,18 +919,26 @@ function get_pagination( $rows_per_page ) {
 
 	$range = 5;// how many pages to show in page link.
 
+	// Usage of $_GET['p'] is safe. It is forced to a number and this function
+	// is only called after a 'manage_options' capability check (see function
+	// display_manage_redirects()).
+	// phpcs:ignore WordPress.Security.NonceVerification.Recommended
 	if ( isset( $_GET['p'] ) && is_numeric( $_GET['p'] ) ) {
 		// cast var as int.
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		$currentpage = (int) $_GET['p'];
 	} else {
 		// default page num.
 		$currentpage = 1;
 	}
 
-	// "complex" placeholder used as string cannot be wrapped in single quotes.
+	// "complex" placeholder used intentionally so that table name is not
+	// wrapped in single quotes.
+	// phpcs:ignore WordPress.DB.PreparedSQLPlaceholders.UnquotedComplexPlaceholder
 	$sql = $wpdb->prepare( 'SELECT COUNT(*) FROM %1s', $tablename );
 
 	// wpdb->prepare used above.
+	// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
 	$numrows = $wpdb->get_var( $sql );
 
 	$totalpages = ceil( $numrows / $rows_per_page );
@@ -1030,14 +1059,19 @@ function add_redirect() {
 				$tablename = $wpdb->prefix . DATABASE_TABLE;
 
 				if ( $id == 0 ) {
-					// "complex" placeholder used as string cannot be wrapped in single quotes.
+					// "complex" placeholder used intentionally so that table
+					// name is not wrapped in single quotes.
+					// phpcs:ignore WordPress.DB.PreparedSQLPlaceholders.UnquotedComplexPlaceholder
 					$sql = $wpdb->prepare( "INSERT INTO %1s (source_url,status,redirect_type,destination_url, added, added_utc) VALUES (%s, 'enabled', %d, %s, Now(), UTC_TIMESTAMP())", $tablename, $before, $redirect_type, $after );
 				} else {
-					// "complex" placeholder used as string cannot be wrapped in single quotes.
+					// "complex" placeholder used intentionally so that table
+					// name is not wrapped in single quotes.
+					// phpcs:ignore WordPress.DB.PreparedSQLPlaceholders.UnquotedComplexPlaceholder
 					$sql = $wpdb->prepare( 'UPDATE %1s SET source_url = %s, redirect_type = %d, destination_url = %s WHERE id = %d', $tablename, $before, $redirect_type, $after, $id );
 				}
 
 				// wpdb->prepare used above.
+				// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
 				$wpdb->query( $sql );
 
 				if ( $id == 0 ) {
@@ -1073,10 +1107,13 @@ function redirect_incoming() {
 		if ( $redirect->status == 'enabled' ) {
 
 			$tablename = $wpdb->prefix . DATABASE_TABLE;
-			// "complex" placeholder used as string cannot be wrapped in single quotes.
+			// "complex" placeholder used intentionally so that table name is
+			// not wrapped in single quotes.
+			// phpcs:ignore WordPress.DB.PreparedSQLPlaceholders.UnquotedComplexPlaceholder
 			$sql = $wpdb->prepare( 'UPDATE %1s SET redirect_count = redirect_count + 1, last_redirect = NOW(), last_redirect_utc = UTC_TIMESTAMP() WHERE ID = %d', $tablename, $redirect->id );
 
-			// wpdb->prepare used above
+			// $wpdb->prepare used above.
+			// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
 			$wpdb->query( $sql );
 
 			if ( strlen( $query_string ) > 0 ) {
@@ -1084,6 +1121,7 @@ function redirect_incoming() {
 			}
 
 			// redirects may not be internal; future version will allow extra hosts for wp_safe_redirect.
+			// phpcs:ignore WordPress.Security.SafeRedirect.wp_redirect_wp_redirect
 			wp_redirect( $redirect->destination_url . $query_string, $redirect->redirect_type );
 			exit;
 
@@ -1103,10 +1141,13 @@ function check_for_redirect( $url ) {
 
 	$tablename = $wpdb->prefix . DATABASE_TABLE;
 
-	// "complex" placeholder used as string cannot be wrapped in single quotes.
+	// "complex" placeholder used intentionally so that table name is not
+	// wrapped in single quotes.
+	// phpcs:ignore WordPress.DB.PreparedSQLPlaceholders.UnquotedComplexPlaceholder
 	$sql = $wpdb->prepare( 'SELECT id,destination_url,redirect_type,status FROM %1s WHERE source_url = %s LIMIT 0,1', $tablename, esc_url_raw( $url ) );
 
 	// wpdb->prepare used above.
+	// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
 	$redirect = $wpdb->get_row( $sql );
 
 	return $redirect;
@@ -1152,18 +1193,23 @@ function add_redirect_for_changed_permalink( $post_id, $post_after, $post_before
 			if ( $redirect ) {
 
 				// insert new redirect.
-				// "complex" placeholder used as string cannot be wrapped in single quotes.
+				// "complex" placeholder used intentionally so that table name
+				// is not wrapped in single quotes.
+				// phpcs:ignore WordPress.DB.PreparedSQLPlaceholders.UnquotedComplexPlaceholder
 				$sql = $wpdb->prepare( 'UPDATE %1s SET destination_url = %s WHERE id = %d', $tablename, $after, $redirect->id );
 
 			} else {
 
 				// insert new redirect.
-				// "complex" placeholder used as string cannot be wrapped in single quotes.
+				// "complex" placeholder used intentionally so that table name
+				// is not wrapped in single quotes.
+				// phpcs:ignore WordPress.DB.PreparedSQLPlaceholders.UnquotedComplexPlaceholder
 				$sql = $wpdb->prepare( "INSERT INTO %1s (source_url,status,redirect_type,destination_url, added, added_utc) VALUES (%s, 'enabled', %d, %s, Now(), UTC_TIMESTAMP())", $tablename, $before, esc_attr( $options['default-redirect'] ), $after );
 
 			}
 
 			// wpdb->prepare used above.
+			// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
 			$wpdb->query( $sql );
 
 		}

--- a/libraries/updateclient/UpdateClient.class.php
+++ b/libraries/updateclient/UpdateClient.class.php
@@ -187,12 +187,17 @@ class UpdateClient {
 
 		// Only need this JS/CSS on the plugin admin page and updates page.
 		if ($screen->base === 'plugins' || $screen->base === 'plugin-install') {
-			// This will make the jQuery below work with various languages.
-			$text1 = esc_html__('Compatible up to:');
-			$text2 = esc_html__('Reviews');
-			$text3 = esc_html__('Read all reviews');
+			// These strings are taken directly from ClassicPress core, so they
+			// should receive the core translations to make the jQuery below
+			// work with various languages.
+			// phpcs:ignore WordPress.WP.I18n.MissingArgDomain
+			$text1 = __('Compatible up to:');
+			// phpcs:ignore WordPress.WP.I18n.MissingArgDomain
+			$text2 = __('Reviews');
+			// phpcs:ignore WordPress.WP.I18n.MissingArgDomain
+			$text3 = __('Read all reviews');
 			// Swap "Compatible up to: 4.9.99" with "Compatible up to: 1.1.1".
-			echo '<script>jQuery(document).ready(function($){$("ul li:contains(4.9.99)").html("<strong>'.$text1.'</strong> '.$this->cp_latest_version.'");$(".fyi h3:contains('.$text2.')").hide();$(".fyi p:contains('.$text3.')").hide();});</script>'."\n";
+			echo '<script>jQuery(document).ready(function($){$("ul li:contains(4.9.99)").html("<strong>'.esc_html($text1).'</strong> '.esc_html($this->cp_latest_version).'");$(".fyi h3:contains('.esc_html($text2).')").hide();$(".fyi p:contains('.esc_html($text3).')").hide();});</script>'."\n";
 			// Styles for the modal window.
 			echo '<style>'."\n";
 			// Hide the ratings text and links to WP.org reviews.
@@ -380,6 +385,8 @@ class UpdateClient {
 		// Add the link to the plugin's or theme's row, if not already existing.
 		if ($this->identifier === $component_file) {
 			$anchors_string = implode('', $component_meta);
+			// Core string used to take advantage of core translations.
+			// phpcs:ignore WordPress.WP.I18n.MissingArgDomain
 			$anchor_text = esc_html__('View details');
 			if (!preg_match('|(\<a[ \s\S\d]*)('.$anchor_text.')(<\/a>)|', $anchors_string)) {
 				$component_meta[] = '<a class="thickbox" href="'.admin_url('/'.$this->config['type'].'-install.php?tab='.$this->config['type'].'-information&'.$this->config['type'].'='.$this->server_slug.'&TB_iframe=true&width=600&height=550').'">'.$anchor_text.'</a>';
@@ -444,13 +451,19 @@ class UpdateClient {
 		// Set destination name.
 		$result['destination_name'] = dirname($hook_extra[$this->config['type']]);
 
+		// Note, this method is only called from the 'upgrader_post_install'
+		// filter so the $_GET parameters are safe (no user input).
+
 		// Updating a plugin or theme?
 		if ($hook_suffix === 'update') {
 			// Got both of the needed arguments?
+			// phpcs:ignore WordPress.Security.NonceVerification.Recommended
 			if (isset($_GET['action'], $_GET[$this->config['type']])) {
 				// First argument is good?
+				// phpcs:ignore WordPress.Security.NonceVerification.Recommended
 				if ($_GET['action'] === 'upgrade-'.$this->config['type']) {
 					// Next argument is good?
+					// phpcs:ignore WordPress.Security.NonceVerification.Recommended
 					if ($_GET[$this->config['type']] === $hook_extra[$this->config['type']]) {
 						// Activate the component.
 						$function = ($this->config['type'] === 'plugin') ? 'activate_plugin' : 'activate_theme';


### PR DESCRIPTION
This PR is a proposed way to fix the coding issues indicated by WPCS / https://github.com/TukuToi/CP-Coding-Standards. We should set a goal of having zero warnings/errors in plugins submitted to the ClassicPress directory, with there being two (or three) ways of meeting this standard:

1. Write code that conforms to the standards - this is also likely to be code that is cleaner and easier to read.
2. Add `// phpcs:ignore` comments with explanatory comments above them. Plugin reviewers will need to look more closely at the code and make sure what is being done makes sense. The tooling allows to also show "ignored" warnings/errors and we can make this even easier in the future.
3. There are probably still some formatting-type rules that we haven't excluded yet, so these should be added to https://github.com/TukuToi/CP-Coding-Standards.

In reviewing this plugin I found a few things that are "non-standard" (as indicated by the automated checks) but none of that is _wrong_ or _insecure_. I will leave some comments inline about specific situations.

See also https://github.com/TukuToi/CP-Coding-Standards/pull/1.